### PR TITLE
Fix the Azure Pipelines build script to properly handle tags

### DIFF
--- a/.azure/scripts/build.sh
+++ b/.azure/scripts/build.sh
@@ -19,7 +19,7 @@ mvn $MVN_ARGS spotbugs:check
 # Push to Nexus
 if [ "$BUILD_REASON" == "PullRequest" ] ; then
     echo "Building Pull Request - nothing to push"
-elif [ "$BRANCH" != "refs/tags/*" ] && [ "$BRANCH" != "refs/heads/master" ]; then
+elif [[ "$BRANCH" != "refs/tags/"* ]] && [ "$BRANCH" != "refs/heads/master" ]; then
     echo "Not in master branch or in release tag - nothing to push"
 else
    if [ "${MAIN_BUILD}" = "TRUE" ] ; then


### PR DESCRIPTION
This does the same fix as strimzi/strimzi-kafka-operator#3802 just to the Mirror Maker extensions -> it fixes the handling of builds in tags.