### PR TITLE
Prepare build to rename master branch to main

### DIFF
--- a/.azure/build-pipeline.yaml
+++ b/.azure/build-pipeline.yaml
@@ -2,7 +2,7 @@
 trigger:
   branches:
     include:
-      - 'master'
+      - 'main'
       - 'release-*'
   tags:
     include:

--- a/.azure/scripts/build.sh
+++ b/.azure/scripts/build.sh
@@ -19,11 +19,11 @@ mvn $MVN_ARGS spotbugs:check
 # Push to Nexus
 if [ "$BUILD_REASON" == "PullRequest" ] ; then
     echo "Building Pull Request - nothing to push"
-elif [[ "$BRANCH" != "refs/tags/"* ]] && [ "$BRANCH" != "refs/heads/master" ]; then
-    echo "Not in master branch or in release tag - nothing to push"
+elif [[ "$BRANCH" != "refs/tags/"* ]] && [ "$BRANCH" != "refs/heads/main" ]; then
+    echo "Not in main branch or in release tag - nothing to push"
 else
    if [ "${MAIN_BUILD}" = "TRUE" ] ; then
-       echo "In master branch or in release tag - pushing to nexus"
+       echo "In main branch or in release tag - pushing to nexus"
        ./.azure/scripts/push-to-nexus.sh
    fi
 fi

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Strimzi Community Code of Conduct
 
-Strimzi Community Code of Conduct is defined in the [governance repository](https://github.com/strimzi/governance/blob/master/CODE_OF_CONDUCT.md).
+Strimzi Community Code of Conduct is defined in the [governance repository](https://github.com/strimzi/governance/blob/main/CODE_OF_CONDUCT.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,3 +1,3 @@
 # Strimzi Governance
 
-Strimzi Governance is defined in the [governance repository](https://github.com/strimzi/governance/blob/master/GOVERNANCE.md).
+Strimzi Governance is defined in the [governance repository](https://github.com/strimzi/governance/blob/main/GOVERNANCE.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,3 @@
 # Strimzi Maintainers list
 
-Strimzi Maintainers list is defined in the [governance repository](https://github.com/strimzi/governance/blob/master/MAINTAINERS).
+Strimzi Maintainers list is defined in the [governance repository](https://github.com/strimzi/governance/blob/main/MAINTAINERS).


### PR DESCRIPTION
This PR updates the build in this repository so that we can rename the `master` branch to `main`.