### PR TITLE
Bump main branch to 1.1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.strimzi</groupId>
     <artifactId>mirror-maker-2-extensions</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <licenses>
 		<license>


### PR DESCRIPTION
As we are working on the 1.0.0 release and the release branch is now created, we should bump the version in the main branch to 1.1.0-SNAPSHOT.