### PR TITLE
Add support for Kafka 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 This repository is an extensions library for use with Mirror Maker 2.
 It allows for example usage of custom replication policies.
 
-
 ## Identity Replication Policy
+
+**Note: From Kafka 3.0.0, Apache Kafka now has its own _Identity Replication Policy_: `org.apache.kafka.connect.mirror.IdentityReplicationPolicy`.
+When using Kafka 3.0.0 and newer, you should use the Apache Kafka policy instead of the Strimzi policy which will be archived in the future.**
 
 MirrorMaker v2 (MM2), which ships as part of Apache Kafka in version 2.4.0 and above, detects and 
 replicates topics, topic partitions, topic configurations and topic ACLs to the destination cluster that matches a regex topic pattern. 

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
 
-        <kafka.version>2.6.0</kafka.version>
+        <kafka.version>3.0.0</kafka.version>
 
         <!-- property to skip surefire tests during failsafe execution -->
         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.30</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/strimzi/kafka/connect/mirror/IdentityReplicationPolicy.java
+++ b/src/main/java/io/strimzi/kafka/connect/mirror/IdentityReplicationPolicy.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
  */
 
 public class IdentityReplicationPolicy extends DefaultReplicationPolicy {
-
     private static final Logger log = LoggerFactory.getLogger(IdentityReplicationPolicy.class);
 
     private String sourceClusterAlias;
@@ -54,7 +53,6 @@ public class IdentityReplicationPolicy extends DefaultReplicationPolicy {
 
     @Override
     public String upstreamTopic(String topic) {
-        return null;
+        return topic;
     }
-
 }


### PR DESCRIPTION
This PR makes the Mirror Maker 2 Extensions and the `IdentityReplicationPolicy` policy to work with Kafka 3.0.0. This is because Kafka 3.0.0 added some additional checks the 1.0.0 version of this policy triggers NPEs. The fix in this PR follows the same logic used in the new `IdentityReplicationPolicy` from Apache Kafka itself. 

This PR also adds a note that users on Kafka 3.0.0 and newer should use the official `IdentityReplicationPolicy` from Kafka. But we should still update this policy to make the upgrades easier and add Strimzi users more time to migrate.