### PR TITLE
Update `IdentityReplicationPolicy` to extend Kafka's own identity replication policy

### DIFF
--- a/.spotbugs/spotbugs-exclude.xml
+++ b/.spotbugs/spotbugs-exclude.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
-  <!-- Empty so far -->
+  <Match>
+    <Class name="io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy" />
+    <Bug pattern="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS" />
+  </Match>
 </FindBugsFilter>

--- a/README.md
+++ b/README.md
@@ -1,33 +1,21 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Twitter Follow](https://img.shields.io/twitter/follow/strimziio.svg?style=social&label=Follow&style=for-the-badge)](https://twitter.com/strimziio)
 
-# Mirror Maker 2 Extensions
-
-This repository is an extensions library for use with Mirror Maker 2.
-It allows for example usage of custom replication policies.
+# MirrorMaker 2 Extensions
 
 ## Identity Replication Policy
 
-**Note: From Kafka 3.0.0, Apache Kafka now has its own _Identity Replication Policy_: `org.apache.kafka.connect.mirror.IdentityReplicationPolicy`.
-When using Kafka 3.0.0 and newer, you should use the Apache Kafka policy instead of the Strimzi policy which will be archived in the future.**
+Replication policies in Apache Kafka MirrorMaker 2 define how will the mirrored topics be named on the target cluster.
+The default replication policy prefixes the topic names with the name of the source cluster.
+Users can provide and configure their own replication policies.
 
-MirrorMaker v2 (MM2), which ships as part of Apache Kafka in version 2.4.0 and above, detects and 
-replicates topics, topic partitions, topic configurations and topic ACLs to the destination cluster that matches a regex topic pattern. 
-Further, it checks for new topics that matches the topic pattern or changes to configurations and ACLs at regular configurable intervals. 
-The topic pattern can also be dynamically changed by changing the configuration of the MirrorSourceConnector. 
-Therefore MM2 can be used to migrate topics and topic data to the destination cluster and keep them in sync.
-                   
-In order to differentiate topics between the source and destination, MM2 utilizes a **ReplicationPolicy**. 
-The **DefaultReplicationPolicy** implementation uses a **\<source-cluster-alias\>.\<topic\>** naming convention as described 
-in [KIP-382](https://cwiki.apachorg/confluence/display/KAFKA/KIP-382%3A+MirrorMaker+2.0#KIP-382:MirrorMaker2.0-RemoteTopics,Partitions).The consumer, 
-when it starts up will subscribe to the replicated topic based on the topic pattern specified which should account for 
-both the source topic and the replicated topic names. This behavior is designed to account for use cases which need to run multiple 
-Apache Kafka clusters and keep them in sync for High Availability/Disaster Recovery and prevent circular replication of topics.
+The identity replication policy provided by Strimzi keeps the topic names on the target cluster the same as they are on the source cluster.  
+The policy is implemented in class `io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy`.
 
-In migration or active-passive DRP scenarios, it might be useful to have the same topic names in the destination as the source as there is no 
-failback requirement and the replication is only way from the source to target Apache Kafka cluster. 
-In order to enable that, the **DefaultReplicationPolicy** needs to be replaced with an **IdentityReplicationPolicy** which would 
-maintain the same topic name at the destination. This jar file needs to be copied into the **libs** directory of the 
-Apache Kafka installation running MM2.
+**From Kafka 3.0.0, Apache Kafka now has its own _Identity Replication Policy_: `org.apache.kafka.connect.mirror.IdentityReplicationPolicy`.
+When using Kafka 3.0.0 and newer, you should use the Apache Kafka policy instead of the Strimzi policy which is deprecated and will be archived in the future.**
 
-Note: inspirations were taken from [here](https://github.com/aws-samples/mirrormaker2-msk-migration).
+From the version 1.2.0, the Strimzi identity replication policy provides exactly the same functionality as Kafka's own policy and works only with Kafka 3.0.0 and newer..
+It is provided only for backwards compatibility reasons for Strimzi users with MirrorMaker 2 clusters configured to use `io.strimzi.kafka.connect.mirror.IdentityReplicationPolicy`.
+
+**If you want to use the identity replication policy with Apache Kafka 2.8 or older, please use the version [1.1.0](https://mvnrepository.com/artifact/io.strimzi/mirror-maker-2-extensions/1.1.0) or [1.0.0](https://mvnrepository.com/artifact/io.strimzi/mirror-maker-2-extensions/1.0.0).**

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.strimzi</groupId>
     <artifactId>mirror-maker-2-extensions</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <licenses>
 		<license>
@@ -80,7 +80,7 @@
         <license.maven.version>2.11</license.maven.version>
         <maven-jar-plugin.version>3.1.0</maven-jar-plugin.version>
 
-        <kafka.version>3.0.0</kafka.version>
+        <kafka.version>3.1.0</kafka.version>
 
         <!-- property to skip surefire tests during failsafe execution -->
         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
@@ -100,30 +100,8 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>connect-mirror</artifactId>
-            <version>${kafka.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
             <artifactId>connect-mirror-client</artifactId>
             <version>${kafka.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.30</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/strimzi/kafka/connect/mirror/IdentityReplicationPolicy.java
+++ b/src/main/java/io/strimzi/kafka/connect/mirror/IdentityReplicationPolicy.java
@@ -4,55 +4,12 @@
  */
 package io.strimzi.kafka.connect.mirror;
 
-import java.util.Map;
-import org.apache.kafka.connect.mirror.DefaultReplicationPolicy;
-import org.apache.kafka.connect.mirror.MirrorConnectorConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
- * <p>
- *   This replication policy is supposed to be used for a simple two-site active-passive Kafka DRP setup where mirroring is always enabled
- *   in one direction only and where names of the downstream topics are not prefixed by Mirror Maker 2, so that switching of the active site
- *   1) does not require reconfiguration of the business services (i.e., we do not have to change names of the topics the services use) and
- *   2) does not add one more prefix to the topic name (i.e., we do not have topic names growing each time the switch happens).
- * </p>
- * <p>
- *   This solution seems to work with Mirror Maker version 2.4.0 but it is 'hacky' because it violates spec of the ReplicationPolicy
- *   interface. According to the spec, if <code>upstreamTopic</code> returns null then <code>topicSource</code> should also return null,
- *   but with this implementation it is not the case. We had to make <code>topicSource</code> return alias of the upstream cluster because
- *   otherwise mirroring of topic properties (e.g., "cleanup.policy=compact") did not work.
- * </p>
+ * The IdentityReplicationPolicy is used to replicate topics using Mirror Maker 2 without changing its name. This class
+ * originally implemented such policy. But since Kafka 3.0.0, such policy is part of Kafka itself and Strimzi does not
+ * need any more its own. It is still supported in Strimzi deployments for backwards compatibility reasons, but it now
+ * only inherits from the original Kafka policy.
  */
-
-public class IdentityReplicationPolicy extends DefaultReplicationPolicy {
-    private static final Logger log = LoggerFactory.getLogger(IdentityReplicationPolicy.class);
-
-    private String sourceClusterAlias;
-
-    @Override
-    public void configure(Map<String, ?> props) {
-        super.configure(props);
-        sourceClusterAlias = (String) props.get(MirrorConnectorConfig.SOURCE_CLUSTER_ALIAS);
-        if (sourceClusterAlias == null) {
-            String logMessage = String.format("Property %s not found", MirrorConnectorConfig.SOURCE_CLUSTER_ALIAS);
-            log.error(logMessage);
-            throw new RuntimeException(logMessage);
-        }
-    }
-
-    @Override
-    public String formatRemoteTopic(String sourceClusterAlias, String topic) {
-        return topic;
-    }
-
-    @Override
-    public String topicSource(String topic) {
-        return topic == null ? null : sourceClusterAlias;
-    }
-
-    @Override
-    public String upstreamTopic(String topic) {
-        return topic;
-    }
+public class IdentityReplicationPolicy extends org.apache.kafka.connect.mirror.IdentityReplicationPolicy {
+    // This class just extends the Apache Kafka for backwards compatibility.
 }


### PR DESCRIPTION
This PR updates the replication policy to just extend Kafka's own `org.apache.kafka.connect.mirror.IdentityReplicationPolicy` to make sure they both work the same without the need for further update. It also updates the version of the main branch to 1.2.0-SNAPSHOT (it looks like it was not updated after the last release).

It also updates the README to clarify the change:
* Make it clear that users should rpefer to use Kafka's own policy
* Explain that it now mirrors Kafka's policy and supports only Kafka 3.0 and newer
* Point users of older Kafka versions to the previous releases

This PR implements the [Strimzi Proposal 34](https://github.com/strimzi/proposals/blob/main/034-deprecate-and-remove-mirror-maker-2-extensions.md). 