### PR TITLE
Bump main branch to 1.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.strimzi</groupId>
     <artifactId>mirror-maker-2-extensions</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
 
     <licenses>
 		<license>


### PR DESCRIPTION
Since the 1.2.0 release is out now, this PR bumps the version in the main branch to 1.3.0-SNAPSHOT.